### PR TITLE
Remove VOC algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If your directory structure differs from the usual setup,
 you can configure the installation script with parameters:
 
 ```
-./install.sh [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>] [-v <klippy venv path>] [-u] 1>&2
+./install.sh [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>] [-u] 1>&2
 ```
 
 > [!WARNING]
@@ -32,8 +32,6 @@ Then, add the following to your `moonraker.conf` to enable automatic updates:
 [update_manager klipper-sgp40]
 type: git_repo
 path: ~/klipper-sgp40
-virtualenv: ~/klippy-env
-requirements: requirements.txt
 origin: https://github.com/thetic/klipper-sgp40.git
 primary_branch: main
 managed_services: klipper
@@ -65,6 +63,10 @@ sensor_type: SGP40
 #   The name of the temperature sensor to use as reference for humidity
 #   compensation of the VOC raw measurement. If not defined calculations
 #   will assume 50% humidity.
+#baseline: 1000
+#   Baseline reading of the sensor.  This should be the "Raw" reading
+#   reported by the `QUERY_SGP40` command. gas readings are reported as
+#   a percentage of this value. The default "baseline" is 1000.
 ```
 
 ### Example

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,9 @@ set -e
 
 KLIPPER_PATH="${HOME}/klipper"
 KLIPPER_SERVICE_NAME=klipper
-KLIPPER_VENV_PATH="${HOME}/klippy-env"
 
 usage() {
-    echo "Usage: $0 [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>] [-v <klippy venv path>] [-u]" 1>&2
+    echo "Usage: $0 [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>] [-u]" 1>&2
 }
 
 # Parse command line arguments
@@ -47,20 +46,6 @@ check_folders() {
         echo "[ERROR] Klipper installation not found in directory $KLIPPER_PATH. Exiting"
         exit 1
     fi
-
-    if [ -f "$KLIPPER_VENV_PATH/bin/python" ]; then
-        echo "Klipper virtual environment found at $KLIPPER_VENV_PATH"
-    else
-        echo "[ERROR] Klipper virtual environment not found in directory $KLIPPER_VENV_PATH. Exiting"
-        exit 1
-    fi
-}
-
-function setup_venv {
-    echo -n "Installing dependencies... "
-    "${KLIPPER_VENV_PATH}/bin/python" -m pip install --upgrade pip
-    "${KLIPPER_VENV_PATH}/bin/python" -m pip install -r "${ROOT_DIR}/requirements.txt"
-    echo "[OK]"
 }
 
 # Link extension to Klipper
@@ -105,7 +90,6 @@ stop_klipper
 if [ -n "$UNINSTALL" ]; then
     uninstall
 else
-    setup_venv
     link_extension
 fi
 start_klipper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "klipper-sgp40"
-dynamic = ["dependencies", "version"]
+dynamic = ["version"]
 requires-python = ">=3.7"
 authors = [
     { name = "Stefan Dej", email = "meteyou@gmail.com" },
@@ -21,8 +21,5 @@ build-backend = "setuptools.build_meta"
 select = ["E4", "E7", "E9", "F", "B", "I"]
 ignore = ["E501"]
 unfixable = ["B"]
-
-[tool.setuptools.dynamic]
-dependencies = { file = ["requirements.txt"] }
 
 [tool.setuptools_scm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-sensirion-gas-index-algorithm==3.2.1


### PR DESCRIPTION
The VOC algorithm measures how close current values are to the last day's worth of readings. This means that readings gradually drop during a long print. This _looks_ like VOCs are decreasing, but it just means the historical average is increasing. It also means that two sensors' VOC readings cannot be compared apples-to-apples. This also makes the sensor values effectively garbage for the first hour after initialization and only slightly useful for the first 24 hours.

I think it makes more sense to report the current raw reading as a percentage of a "normal" reading.  This prevents problems with hysteresis and keeps sensors' readings in comparable domains.

In the future, I'd like to create a calibration command, that samples sensors' raw values over a period of time and writes an appropriate baseline to the config file.