### PR TITLE
Defer reading measurements until next cycle

### DIFF
--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -267,12 +267,15 @@ class SGP40:
         self.i2c.i2c_write(cmd)
 
         # Wait
-        self.reactor.pause(self.reactor.monotonic() + wait_time_s)
+        self._wait_ms(wait_time_s * 1000)
 
         if read_len:
             return self._read(read_len)
         else:
             return []
+
+    def _wait_ms(self, ms):
+        self.reactor.pause(self.reactor.monotonic() + ms / 1000)
 
     def _read(self, len=1):
         chunk_size = SGP40_WORD_LEN + 1

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -269,21 +269,26 @@ class SGP40:
         # Wait
         self.reactor.pause(self.reactor.monotonic() + wait_time_s)
 
+        if read_len:
+            return self._read(read_len)
+        else:
+            return []
+
+    def _read(self, len=1):
         chunk_size = SGP40_WORD_LEN + 1
-        reply_len = read_len * chunk_size  # CRC every word
+        reply_len = len * chunk_size  # CRC every word
 
         data = []
 
-        if reply_len:
-            params = self.i2c.i2c_read([], reply_len)
-            response = bytearray(params["response"])
+        params = self.i2c.i2c_read([], reply_len)
+        response = bytearray(params["response"])
 
-            for i in range(0, reply_len, chunk_size):
-                if not _check_crc8(
-                    response[i : i + SGP40_WORD_LEN], response[i + SGP40_WORD_LEN]
-                ):
-                    logging.warning(self._log_message("Checksum error on read!"))
-                data.append(unpack_from(">H", response[i : i + SGP40_WORD_LEN])[0])
+        for i in range(0, reply_len, chunk_size):
+            if not _check_crc8(
+                response[i : i + SGP40_WORD_LEN], response[i + SGP40_WORD_LEN]
+            ):
+                logging.warning(self._log_message("Checksum error on read!"))
+            data.append(unpack_from(">H", response[i : i + SGP40_WORD_LEN])[0])
 
         return data
 


### PR DESCRIPTION
Apparently some SGP40's can take much longer than the specified 30ms to return a new measurement. Adafruit's implementation [waits *250ms*](https://github.com/adafruit/Adafruit_SGP40/blob/master/src/Adafruit_SGP40.cpp#L163) to read a measurement.

It's not practical to pause for a quarter second when the system has other things to do. This change initiates a new measurement at the _end_ of it's cycle and instead of pausing, defers reading that measurement until the beginning of the next cycle.