### PR TITLE
Let users configure linked heaters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ sensor_type: SGP40
 #   The name of the temperature sensor to use as reference for humidity
 #   compensation of the VOC raw measurement. If not defined calculations
 #   will assume 50% humidity.
+#heater: extruder
+#   Name of the config section defining any heater that produces VOCs.
+#   If a comma separated list of heater names is provided here, then
+#   calibration will be disabled when any of the given heaters are enabled.
+#   The default is "extruder".
+#heater_temp: 75.0
+#   A temperature (in Celsius) that the heater must rise above before
+#   calibration is disabled. The default is 75 Celsius.
 ```
 
 ### Example

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -212,15 +212,17 @@ class SGP40:
 
         self.step_timer = self.reactor.register_timer(self._handle_step)
 
-    def _is_hot(self, heater, eventtime):
-        current_temp, target_temp = heater.get_temp(eventtime)
-        return target_temp or current_temp > self.heater_temp
+    def _is_hot(self, eventtime):
+        for heater in self._heaters:
+            current_temp, target_temp = heater.get_temp(eventtime)
+            if target_temp or current_temp > self.heater_temp:
+                return True
+        else:
+            return False
 
     def _handle_step(self, eventtime):
         # Check for heating
-        self._gia.calibrating = not any(
-            self._is_hot(h, eventtime) for h in self._heaters
-        )
+        self._gia.calibrating = not self._is_hot(eventtime)
 
         if self._measuring:
             # Calculate VOC index


### PR DESCRIPTION
Instead of trying to find all the extruders, this change defaults the linked heaters to just `extruder`, but allows configuration to use any heater(s).