### PR TITLE
Hack in more I2C retries

### DIFF
--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -8,6 +8,7 @@
 import logging
 import math
 import re
+from logging import ERROR, WARNING
 from struct import unpack_from
 
 from .. import bus  # type:ignore
@@ -213,7 +214,7 @@ class SGP40:
         self._wait_ms(500)
         response = self._read()
         if response[0] != 0xD400:
-            logging.error(self._log_message("Self test error"))
+            self._log(ERROR, "Self test error")
 
         self.step_timer = self.reactor.register_timer(self._handle_step)
 
@@ -286,13 +287,13 @@ class SGP40:
             if not _check_crc8(
                 response[i : i + SGP40_WORD_LEN], response[i + SGP40_WORD_LEN]
             ):
-                logging.warning(self._log_message("Checksum error on read!"))
+                self._log(WARNING, "Checksum error on read!")
             data.append(unpack_from(">H", response[i : i + SGP40_WORD_LEN])[0])
 
         return data
 
-    def _log_message(self, message):
-        return "SGP40 %s: %s" % (self.name, message)
+    def _log(self, level, msg):
+        logging.log(level, "SGP40 %s: %s" % (self.name, msg))
 
     def get_status(self, eventtime):
         return {

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -11,7 +11,8 @@ import re
 from logging import ERROR, WARNING
 from struct import unpack_from
 
-from ...serialhdl import error  # type: ignore
+from serialhdl import error  # type: ignore
+
 from .. import bus  # type: ignore
 from .gia import GasIndexAlgorithm
 


### PR DESCRIPTION
Restore old logic from nevermore_max implementation that monkeypatches more retries into the I2C reads. This is on top of existing deferred read mitigation. Attempt to address https://github.com/xbst/Nevermore-Sensors/issues/1