### PR TITLE
Report zeroed raw readings

### DIFF
--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -227,8 +227,9 @@ class SGP40:
         if self._measuring:
             # Calculate VOC index
             response = self._read()
-            self.raw = response[0]
-            self.voc = self._gia.process(self.raw)
+            raw = response[0]
+            self.voc = self._gia.process(raw)
+            self.raw = self._gia.raw
 
         # Get reference temperature
         if self.temp_sensor:

--- a/src/klipper_sgp40/gia.py
+++ b/src/klipper_sgp40/gia.py
@@ -121,6 +121,10 @@ class GasIndexAlgorithm:
     def sampling_interval(self):
         return self._sampling_interval
 
+    @property
+    def raw(self):
+        return self._sraw
+
     def process(self, sraw):
         """Calculate the gas index value from the raw sensor value.
 


### PR DESCRIPTION
The sensor reports misleadingly high numbers. The GIA already zeroes these. This uses the GIA's zeroed values instead of the sensor's. This matches the numbers used for calibration.