### PR TITLE
Fix for klipper v0.13.0-159-g37ddab223 and greater

### DIFF
--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -7,6 +7,7 @@
 
 import logging
 import math
+import inspect
 from logging import ERROR, WARNING
 from struct import unpack_from
 
@@ -21,9 +22,16 @@ SGP40_WORD_LEN = 2
 HEATER_OFF_CMD = [0x36, 0x15]
 SELF_TEST_CMD = [0x28, 0x0E]
 MEASURE_RAW_CMD_PREFIX = [0x26, 0x0F]
+# Get response key signature for klipper v0.13.0-159-g37ddab223 and greater
+RESPONSE_EXPECTED_KEYS = ["self", "cmds", "cmd_queue", "minclock", "reqclock", "retry"]
 
+# Fixes for klipper v0.13.0-159-g37ddab223 and greater
+def _get_response_new(self, cmds, cmd_queue, minclock=0, reqclock=0, retry=True):
+    return _get_response(self, cmds, cmd_queue, minclock, reqclock)
 
 # Hack i2c to attempt more retries.
+# This function is for klipper versions older than v0.13.0-159 and
+#   kalico as of(10/31/2025)
 def _get_response(self, cmds, cmd_queue, minclock=0, reqclock=0):
     retries = 15
     retry_delay = 0.010
@@ -198,6 +206,10 @@ class SGP40:
             raise self.printer.config_error("'%s' does not report %s." % (name, value))
 
     def _handle_connect(self):
+        # Query signature for i2c get_response method
+        response_sig = inspect.signature(self.i2c.i2c_read_cmd._xmit_helper.get_response)
+        response_keys = list(response_sig.parameters.keys())
+
         if self.temp_sensor:
             self._check_ref_sensor(self.temp_sensor, "temperature")
         if self.humidity_sensor:
@@ -206,7 +218,11 @@ class SGP40:
 
         self._init_sgp40()
 
-        self.i2c.i2c_read_cmd._xmit_helper.get_response = _get_response
+        # Check if response keys match for Klipper v0.13.0-159-g37ddab223 and greater
+        if response_keys == RESPONSE_EXPECTED_KEYS:
+            self.i2c.i2c_read_cmd._xmit_helper.get_response = _get_response_new
+        else:
+            self.i2c.i2c_read_cmd._xmit_helper.get_response = _get_response
 
         self.reactor.update_timer(self.step_timer, self.reactor.NOW)
 


### PR DESCRIPTION
Added `get_response` signature check to check which `_get_response` function to reassign since klipper  v0.13.0-159-g37ddab223 and up added a new `retry=True` variable.
- Verified backwards compatibility with older klipper and kalico
- Used Isiks Tech BME280 & SGP40 Air Quality Sensors for verification

Fixes: #35 