### PR TITLE
Add graceful I2C error handling to prevent printer shutdowns

### DIFF
--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -10,7 +10,7 @@ import math
 from logging import ERROR, WARNING
 from struct import unpack_from
 
-from .. import bus  # type: ignore
+from .. import bus, mcu  # type: ignore
 from .gia import GasIndexAlgorithm
 
 SGP40_CHIP_ADDR = 0x59
@@ -225,13 +225,18 @@ class SGP40:
         self._gia.calibrating = not self._is_hot(eventtime)
 
         if self._measuring:
-            # Calculate VOC index
-            response = self._read()
-            raw = response[0]
-            self.voc = self._gia.process(raw)
-            self.raw = self._gia.raw
-            # Small delay after read to prevent I2C bus conflicts
-            self._wait_ms(20)
+            try:
+                # Calculate VOC index
+                response = self._read()
+                raw = response[0]
+                self.voc = self._gia.process(raw)
+                self.raw = self._gia.raw
+                # Small delay after read to prevent I2C bus conflicts
+                self._wait_ms(20)
+            except mcu.error as e:
+                self._log(WARNING, "Measurement read failed: %s" % (str(e),))
+                # Keep previous values and continue measurement cycle
+                self._measuring = False
 
         # Get reference temperature
         if self.temp_sensor:
@@ -255,14 +260,18 @@ class SGP40:
         else:
             self.humidity = humidity
 
-        # Start next measurement
-        cmd = (
-            MEASURE_RAW_CMD_PREFIX
-            + _humidity_to_ticks(self.humidity)
-            + _temperature_to_ticks(self.temp)
-        )
-        self.i2c.i2c_write(cmd)
-        self._measuring = True
+        try:
+            # Start next measurement
+            cmd = (
+                MEASURE_RAW_CMD_PREFIX
+                + _humidity_to_ticks(self.humidity)
+                + _temperature_to_ticks(self.temp)
+            )
+            self.i2c.i2c_write(cmd)
+            self._measuring = True
+        except mcu.error as e:
+            self._log(WARNING, "Measurement write failed: %s" % (str(e),))
+            self._measuring = False
 
         # Schedule next step
         measured_time = self.reactor.monotonic()

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -10,7 +10,7 @@ import math
 from logging import ERROR, WARNING
 from struct import unpack_from
 
-from .. import bus, mcu  # type: ignore
+from .. import bus  # type: ignore
 from .gia import GasIndexAlgorithm
 
 SGP40_CHIP_ADDR = 0x59
@@ -233,8 +233,8 @@ class SGP40:
                 self.raw = self._gia.raw
                 # Small delay after read to prevent I2C bus conflicts
                 self._wait_ms(20)
-            except mcu.error as e:
-                self._log(WARNING, "Measurement read failed: %s" % (str(e),))
+            except Exception:
+                logging.exception("SGP40: Error reading data")
                 # Keep previous values and continue measurement cycle
                 self._measuring = False
 
@@ -269,8 +269,8 @@ class SGP40:
             )
             self.i2c.i2c_write(cmd)
             self._measuring = True
-        except mcu.error as e:
-            self._log(WARNING, "Measurement write failed: %s" % (str(e),))
+        except Exception:
+            logging.exception("SGP40: Error writing data")
             self._measuring = False
 
         # Schedule next step


### PR DESCRIPTION
## Summary

Add graceful I2C error handling to prevent printer shutdowns from transient I2C communication failures.

## Context

Klipper PR [#7013](https://github.com/Klipper3d/klipper/pull/7013) (merged Feb 7, 2026) changed I2C error handling from MCU-side to host-side. I2C errors now raise `mcu.error` exceptions in Python that trigger printer shutdowns if not caught.

This PR adds try-except blocks around I2C operations in the measurement loop to catch these exceptions, log warnings, and continue operating with previous sensor values rather than shutting down the printer.

## Changes

- Wrap I2C operations in try-except to catch communication failures
- Log warnings and continue measurement cycle on errors

## Compatibility

**Klipper (current):** This change is effective immediately for users on Klipper v0.13.0+ with PR #7013's host-side error handling.

**Kalico (current):** Kalico does not yet have Klipper's PR [#7013](https://github.com/Klipper3d/klipper/pull/7013) changes. On Kalico, I2C errors still trigger MCU-side shutdowns that occur below the Python layer, so this error handling won't prevent those shutdowns. However, the changes are forward-compatible and will become effective when Kalico syncs these upstream changes.