### PR TITLE
Prevent nuisance shutdowns from transient I2C NACK errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This is a [Klipper](https://www.klipper3d.org/) module that provides support for
 ## Requirements
 
 - **Klipper**: v0.13.0-159 or newer
-- **Kalico**: commit `fb7b58f` (2026-01-22) or newer
 
 ## Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ sensor_type: SGP40
 #   calibration is disabled. The default is 75 Celsius.
 ```
 
+> [!WARNING]
+> Any I2C sensor configured as `ref_temp_sensor` or `ref_humidity_sensor` will have its I2C
+> error handling modified so that transient NACK errors are logged rather than triggering a
+> printer shutdown. These sensors **must not** be used for heater control — this modification
+> would prevent a hardware fault from safely shutting down the printer.
+
 ### Example
 
 The following is an example using a [Nevermore PCB](https://github.com/xbst/Nevermore-PCB/tree/master)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ sensor_type: SGP40
 #   The name of the temperature sensor to use as reference for humidity
 #   compensation of the VOC raw measurement. If not defined calculations
 #   will assume 50% humidity.
+#
+#   WARNING: Any I2C sensor configured as ref_temp_sensor or
+#   ref_humidity_sensor will have its I2C error handling modified so that
+#   transient NACK errors are logged rather than triggering a printer
+#   shutdown. These sensors MUST NOT be used for heater control, as this
+#   modification would prevent a hardware fault from safely shutting down
+#   the printer.
 #heater: extruder
 #   Name of the config section defining any heater that produces VOCs.
 #   If a comma separated list of heater names is provided here, then

--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@ This is a [Klipper](https://www.klipper3d.org/) module that provides support for
 
 ## Requirements
 
-This module requires:
-
 - **Klipper**: v0.13.0-159 or newer
 - **Kalico**: commit `fb7b58f` (2026-01-22) or newer
-
-These versions include improved I2C retry logic and NACK handling that are essential for reliable sensor communication.
-Older versions are no longer supported.
 
 ## Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This is a [Klipper](https://www.klipper3d.org/) module that provides support for
 
 - **Klipper**: v0.13.0-159 or newer
 
+> [!NOTE]
+> This module should work in [Kalico](https://docs.kalico.gg/), but expect periodic printer shutdowns from I2C disconnections.
+
 ## Installation instructions
 
 The module can be installed into a existing Klipper installation with an install script.

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -327,20 +327,7 @@ class SGP40:
     def _read(self, count=1):
         chunk_size = SGP40_WORD_LEN + 1
         reply_len = count * chunk_size
-
-        retries = 5
-        params = None
-        last_error = None
-        while retries > 0 and params is None:
-            try:
-                params = self.i2c.i2c_read([], reply_len)
-            except self.printer.command_error as e:
-                last_error = e
-                self._wait_ms(500)
-                retries -= 1
-        if params is None:
-            raise last_error
-
+        params = self.i2c.i2c_read([], reply_len)
         response = bytearray(params["response"])
         data = []
         for i in range(0, reply_len, chunk_size):

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -316,7 +316,7 @@ class SGP40:
             self._callback(self.mcu.estimated_print_time(measured_time), self.voc)
             return measured_time + self._gia.sampling_interval
         except Exception:
-            logging.exception("SGP40 %s: Error reading data" % self.name)
+            logging.exception("SGP40 %s: Error during measurement step" % self.name)
             self.temp = self.humidity = 0.0
             self._measuring = False
             return self.reactor.monotonic() + self._gia.sampling_interval * 5

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -191,34 +191,40 @@ class SGP40:
 
     def _patch_i2c(self, i2c):
         # bus.py's i2c_transfer() calls invoke_shutdown() on any non-SUCCESS
-        # I2C status, crashing the printer on transient NACK errors. Patch
-        # this device's transfer method to raise command_error instead so our
-        # retry logic can handle it without taking down the printer.
-        if getattr(i2c, "i2c_transfer_cmd", None) is None:
+        # I2C status, crashing the printer on transient NACK errors.
+        #
+        # We wrap i2c_transfer_cmd (a plain data attribute) so that its send()
+        # raises command_error for non-SUCCESS statuses. The original
+        # i2c_transfer() method still runs, but the exception propagates before
+        # it can reach invoke_shutdown().  Replacing the cmd object is more
+        # reliable than patching the i2c_transfer method because Python method
+        # descriptors can prevent instance-attribute method patches from taking
+        # effect in some call paths.
+        original_cmd = getattr(i2c, "i2c_transfer_cmd", None)
+        if original_cmd is None:
             return  # Kalico, or Klipper with post-#7013 MCU firmware: already raises command_error natively
         command_error = self.printer.command_error
+        mcu = i2c.mcu
+        mcu_name = mcu.get_name()
+        i2c_address = i2c.i2c_address
 
-        def _safe_transfer(write, read_len=0, minclock=0, reqclock=0, retry=True):
-            if i2c.mcu.is_fileoutput():
-                i2c.i2c_transfer_cmd.send(
-                    [i2c.oid, write, read_len], minclock=minclock, reqclock=reqclock
+        class _SafeTransferCmd:
+            def send(self, data=(), minclock=0, reqclock=0, retry=True):
+                if mcu.is_fileoutput():
+                    original_cmd.send(data, minclock=minclock, reqclock=reqclock)
+                    return
+                param = original_cmd.send(
+                    data, minclock=minclock, reqclock=reqclock, retry=retry
                 )
-                return
-            param = i2c.i2c_transfer_cmd.send(
-                [i2c.oid, write, read_len],
-                minclock=minclock,
-                reqclock=reqclock,
-                retry=retry,
-            )
-            status = param["i2c_bus_status"]
-            if status == "SUCCESS":
-                return param
-            raise command_error(
-                "MCU '%s' I2C request to addr %i reports error %s"
-                % (i2c.mcu.get_name(), i2c.i2c_address, status)
-            )
+                status = param["i2c_bus_status"]
+                if status == "SUCCESS":
+                    return param
+                raise command_error(
+                    "MCU '%s' I2C request to addr %i reports error %s"
+                    % (mcu_name, i2c_address, status)
+                )
 
-        i2c.i2c_transfer = _safe_transfer
+        i2c.i2c_transfer_cmd = _SafeTransferCmd()
 
     def _handle_ready(self):
         pheaters = self.printer.lookup_object("heaters")

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -194,8 +194,8 @@ class SGP40:
         # I2C status, crashing the printer on transient NACK errors. Patch
         # this device's transfer method to raise command_error instead so our
         # retry logic can handle it without taking down the printer.
-        if i2c.i2c_transfer_cmd is None:
-            return  # Legacy firmware path already raises command_error natively
+        if getattr(i2c, "i2c_transfer_cmd", None) is None:
+            return  # Legacy firmware / Kalico path already raises command_error natively
         command_error = self.printer.command_error
 
         def _safe_transfer(write, read_len=0, minclock=0, reqclock=0, retry=True):
@@ -314,7 +314,7 @@ class SGP40:
         last_error = None
         while retries > 0 and params is None:
             try:
-                params = self.i2c.i2c_read([], reply_len, retry=False)
+                params = self.i2c.i2c_read([], reply_len)
             except self.printer.command_error as e:
                 last_error = e
                 self._wait_ms(500)

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -16,6 +16,33 @@ from .gia import GasIndexAlgorithm
 SGP40_CHIP_ADDR = 0x59
 SGP40_WORD_LEN = 2
 
+
+class _SafeTransferCmd:
+    # Wraps i2c_transfer_cmd.send() to raise command_error instead of calling
+    # invoke_shutdown() on non-SUCCESS I2C statuses.
+    def __init__(self, original_cmd, command_error, mcu, mcu_name, i2c_address):
+        self._original_cmd = original_cmd
+        self._command_error = command_error
+        self._mcu = mcu
+        self._mcu_name = mcu_name
+        self._i2c_address = i2c_address
+
+    def send(self, data=(), minclock=0, reqclock=0, retry=True):
+        if self._mcu.is_fileoutput():
+            self._original_cmd.send(data, minclock=minclock, reqclock=reqclock)
+            return
+        param = self._original_cmd.send(
+            data, minclock=minclock, reqclock=reqclock, retry=retry
+        )
+        status = param["i2c_bus_status"]
+        if status == "SUCCESS":
+            return param
+        raise self._command_error(
+            "MCU '%s' I2C request to addr %i reports error %s"
+            % (self._mcu_name, self._i2c_address, status)
+        )
+
+
 HEATER_OFF_CMD = [0x36, 0x15]
 SELF_TEST_CMD = [0x28, 0x0E]
 MEASURE_RAW_CMD_PREFIX = [0x26, 0x0F]
@@ -201,30 +228,16 @@ class SGP40:
         # descriptors can prevent instance-attribute method patches from taking
         # effect in some call paths.
         original_cmd = getattr(i2c, "i2c_transfer_cmd", None)
-        if original_cmd is None:
-            return  # Kalico, or Klipper with post-#7013 MCU firmware: already raises command_error natively
-        command_error = self.printer.command_error
+        if original_cmd is None or isinstance(original_cmd, _SafeTransferCmd):
+            return  # already patched, or Kalico/post-#7013 firmware (raises command_error natively)
         mcu = i2c.mcu
-        mcu_name = mcu.get_name()
-        i2c_address = i2c.i2c_address
-
-        class _SafeTransferCmd:
-            def send(self, data=(), minclock=0, reqclock=0, retry=True):
-                if mcu.is_fileoutput():
-                    original_cmd.send(data, minclock=minclock, reqclock=reqclock)
-                    return
-                param = original_cmd.send(
-                    data, minclock=minclock, reqclock=reqclock, retry=retry
-                )
-                status = param["i2c_bus_status"]
-                if status == "SUCCESS":
-                    return param
-                raise command_error(
-                    "MCU '%s' I2C request to addr %i reports error %s"
-                    % (mcu_name, i2c_address, status)
-                )
-
-        i2c.i2c_transfer_cmd = _SafeTransferCmd()
+        i2c.i2c_transfer_cmd = _SafeTransferCmd(
+            original_cmd,
+            self.printer.command_error,
+            mcu,
+            mcu.get_name(),
+            i2c.i2c_address,
+        )
 
     def _handle_ready(self):
         pheaters = self.printer.lookup_object("heaters")

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -195,7 +195,7 @@ class SGP40:
         # this device's transfer method to raise command_error instead so our
         # retry logic can handle it without taking down the printer.
         if getattr(i2c, "i2c_transfer_cmd", None) is None:
-            return  # Legacy firmware / Kalico path already raises command_error natively
+            return  # Kalico, or Klipper with post-#7013 MCU firmware: already raises command_error natively
         command_error = self.printer.command_error
 
         def _safe_transfer(write, read_len=0, minclock=0, reqclock=0, retry=True):

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -111,6 +111,7 @@ class SGP40:
         self.min_temp = self.max_temp = 0
         self.step_timer = None
         self._measuring = False
+        self._ref_sensors = []
 
         mean = config.getfloat("voc_mean", None)
         stddev = config.getfloat("voc_stddev", None)
@@ -203,6 +204,8 @@ class SGP40:
 
         if hasattr(sensor, "i2c"):
             self._patch_i2c(sensor.i2c)
+            if hasattr(sensor, "sample_timer") and sensor not in self._ref_sensors:
+                self._ref_sensors.append(sensor)
 
     def _handle_connect(self):
         if self.temp_sensor:
@@ -298,6 +301,16 @@ class SGP40:
         self.humidity = (
             humidity if humidity is not None else _estimate_humidity(self.temp)
         )
+
+        # BME280 sets temp/humidity to 0 and returns reactor.NEVER on I2C error,
+        # permanently stopping its sample timer.  Reschedule it so it can recover
+        # on its own after a transient NACK without requiring a printer restart.
+        for sensor in self._ref_sensors:
+            if getattr(sensor, "temp", None) == 0.0:
+                self.reactor.update_timer(
+                    sensor.sample_timer,
+                    self.reactor.monotonic() + self._gia.sampling_interval,
+                )
 
         cmd = (
             MEASURE_RAW_CMD_PREFIX

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -279,51 +279,49 @@ class SGP40:
             return False
 
     def _handle_step(self, eventtime):
-        try:
-            self._gia.calibrating = not self._is_hot(eventtime)
+        self._gia.calibrating = not self._is_hot(eventtime)
 
+        if self.temp_sensor:
+            self.temp = self.printer.lookup_object(
+                "{}".format(self.temp_sensor)
+            ).get_status(eventtime)["temperature"]
+        else:
+            self.temp = 25
+
+        humidity = None
+        if self.humidity_sensor:
+            humidity = (
+                self.printer.lookup_object("{}".format(self.humidity_sensor))
+                .get_status(eventtime)
+                .get("humidity")
+            )
+        self.humidity = (
+            humidity if humidity is not None else _estimate_humidity(self.temp)
+        )
+
+        cmd = (
+            MEASURE_RAW_CMD_PREFIX
+            + _humidity_to_ticks(self.humidity)
+            + _temperature_to_ticks(self.temp)
+        )
+        try:
             if self._measuring:
                 response = self._read()
                 raw = response[0]
                 self.voc = self._gia.process(raw)
                 self.raw = self._gia.raw
                 self._wait_ms(20)
-
-            if self.temp_sensor:
-                self.temp = self.printer.lookup_object(
-                    "{}".format(self.temp_sensor)
-                ).get_status(eventtime)["temperature"]
-            else:
-                self.temp = 25
-
-            humidity = None
-            if self.humidity_sensor:
-                humidity = (
-                    self.printer.lookup_object("{}".format(self.humidity_sensor))
-                    .get_status(eventtime)
-                    .get("humidity")
-                )
-            if humidity is None:
-                self.humidity = _estimate_humidity(self.temp)
-            else:
-                self.humidity = humidity
-
-            cmd = (
-                MEASURE_RAW_CMD_PREFIX
-                + _humidity_to_ticks(self.humidity)
-                + _temperature_to_ticks(self.temp)
-            )
             self.i2c.i2c_write(cmd)
             self._measuring = True
-
-            measured_time = self.reactor.monotonic()
-            self._callback(self.mcu.estimated_print_time(measured_time), self.voc)
-            return measured_time + self._gia.sampling_interval
         except Exception:
             logging.exception("SGP40 %s: Error during measurement step" % self.name)
             self.temp = self.humidity = 0.0
             self._measuring = False
             return self.reactor.monotonic() + self._gia.sampling_interval * 5
+
+        measured_time = self.reactor.monotonic()
+        self._callback(self.mcu.estimated_print_time(measured_time), self.voc)
+        return measured_time + self._gia.sampling_interval
 
     def _wait_ms(self, ms):
         self.reactor.pause(self.reactor.monotonic() + ms / 1000)

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -174,6 +174,9 @@ class SGP40:
         if value and value not in reported:
             raise self.printer.config_error("'%s' does not report %s." % (name, value))
 
+        if hasattr(sensor, "i2c"):
+            self._patch_i2c(sensor.i2c)
+
     def _handle_connect(self):
         if self.temp_sensor:
             self._check_ref_sensor(self.temp_sensor, "temperature")
@@ -181,20 +184,19 @@ class SGP40:
             # BME280 does not start reporting humidity until after connection.
             self._check_ref_sensor(self.humidity_sensor)
 
-        self._patch_i2c()
+        self._patch_i2c(self.i2c)
         self._init_sgp40()
 
         self.reactor.update_timer(self.step_timer, self.reactor.NOW)
 
-    def _patch_i2c(self):
+    def _patch_i2c(self, i2c):
         # bus.py's i2c_transfer() calls invoke_shutdown() on any non-SUCCESS
         # I2C status, crashing the printer on transient NACK errors. Patch
         # this device's transfer method to raise command_error instead so our
         # retry logic can handle it without taking down the printer.
-        if self.i2c.i2c_transfer_cmd is None:
+        if i2c.i2c_transfer_cmd is None:
             return  # Legacy firmware path already raises command_error natively
         command_error = self.printer.command_error
-        i2c = self.i2c
 
         def _safe_transfer(write, read_len=0, minclock=0, reqclock=0, retry=True):
             if i2c.mcu.is_fileoutput():

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -212,6 +212,10 @@ class SGP40:
             self._check_ref_sensor(self.humidity_sensor)
 
         self._patch_i2c(self.i2c)
+        # Intentionally no try/except: the sensor must respond at startup.
+        # Transient NACKs during the measurement loop are handled in
+        # _handle_step, but a sensor that is absent or unresponsive at connect
+        # time should be a hard failure.
         self._init_sgp40()
 
         self.reactor.update_timer(self.step_timer, self.reactor.NOW)

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -181,9 +181,42 @@ class SGP40:
             # BME280 does not start reporting humidity until after connection.
             self._check_ref_sensor(self.humidity_sensor)
 
+        self._patch_i2c()
         self._init_sgp40()
 
         self.reactor.update_timer(self.step_timer, self.reactor.NOW)
+
+    def _patch_i2c(self):
+        # bus.py's i2c_transfer() calls invoke_shutdown() on any non-SUCCESS
+        # I2C status, crashing the printer on transient NACK errors. Patch
+        # this device's transfer method to raise command_error instead so our
+        # retry logic can handle it without taking down the printer.
+        if self.i2c.i2c_transfer_cmd is None:
+            return  # Legacy firmware path already raises command_error natively
+        command_error = self.printer.command_error
+        i2c = self.i2c
+
+        def _safe_transfer(write, read_len=0, minclock=0, reqclock=0, retry=True):
+            if i2c.mcu.is_fileoutput():
+                i2c.i2c_transfer_cmd.send(
+                    [i2c.oid, write, read_len], minclock=minclock, reqclock=reqclock
+                )
+                return
+            param = i2c.i2c_transfer_cmd.send(
+                [i2c.oid, write, read_len],
+                minclock=minclock,
+                reqclock=reqclock,
+                retry=retry,
+            )
+            status = param["i2c_bus_status"]
+            if status == "SUCCESS":
+                return param
+            raise command_error(
+                "MCU '%s' I2C request to addr %i reports error %s"
+                % (i2c.mcu.get_name(), i2c.i2c_address, status)
+            )
+
+        i2c.i2c_transfer = _safe_transfer
 
     def _handle_ready(self):
         pheaters = self.printer.lookup_object("heaters")
@@ -221,73 +254,80 @@ class SGP40:
             return False
 
     def _handle_step(self, eventtime):
-        # Check for heating
-        self._gia.calibrating = not self._is_hot(eventtime)
+        try:
+            self._gia.calibrating = not self._is_hot(eventtime)
 
-        if self._measuring:
-            # Calculate VOC index
-            response = self._read()
-            raw = response[0]
-            self.voc = self._gia.process(raw)
-            self.raw = self._gia.raw
-            # Small delay after read to prevent I2C bus conflicts
-            self._wait_ms(20)
+            if self._measuring:
+                response = self._read()
+                raw = response[0]
+                self.voc = self._gia.process(raw)
+                self.raw = self._gia.raw
+                self._wait_ms(20)
 
-        # Get reference temperature
-        if self.temp_sensor:
-            self.temp = self.printer.lookup_object(
-                "{}".format(self.temp_sensor)
-            ).get_status(eventtime)["temperature"]
-        else:
-            # Temperatures defaults to 25C
-            self.temp = 25
+            if self.temp_sensor:
+                self.temp = self.printer.lookup_object(
+                    "{}".format(self.temp_sensor)
+                ).get_status(eventtime)["temperature"]
+            else:
+                self.temp = 25
 
-        # Get reference humidity
-        humidity = None
-        if self.humidity_sensor:
-            humidity = (
-                self.printer.lookup_object("{}".format(self.humidity_sensor))
-                .get_status(eventtime)
-                .get("humidity")
+            humidity = None
+            if self.humidity_sensor:
+                humidity = (
+                    self.printer.lookup_object("{}".format(self.humidity_sensor))
+                    .get_status(eventtime)
+                    .get("humidity")
+                )
+            if humidity is None:
+                self.humidity = _estimate_humidity(self.temp)
+            else:
+                self.humidity = humidity
+
+            cmd = (
+                MEASURE_RAW_CMD_PREFIX
+                + _humidity_to_ticks(self.humidity)
+                + _temperature_to_ticks(self.temp)
             )
-        if humidity is None:
-            self.humidity = _estimate_humidity(self.temp)
-        else:
-            self.humidity = humidity
+            self.i2c.i2c_write(cmd)
+            self._measuring = True
 
-        # Start next measurement
-        cmd = (
-            MEASURE_RAW_CMD_PREFIX
-            + _humidity_to_ticks(self.humidity)
-            + _temperature_to_ticks(self.temp)
-        )
-        self.i2c.i2c_write(cmd)
-        self._measuring = True
-
-        # Schedule next step
-        measured_time = self.reactor.monotonic()
-        self._callback(self.mcu.estimated_print_time(measured_time), self.voc)
-        return measured_time + self._gia.sampling_interval
+            measured_time = self.reactor.monotonic()
+            self._callback(self.mcu.estimated_print_time(measured_time), self.voc)
+            return measured_time + self._gia.sampling_interval
+        except Exception:
+            logging.exception("SGP40 %s: Error reading data" % self.name)
+            self.temp = self.humidity = 0.0
+            self._measuring = False
+            return self.reactor.monotonic() + self._gia.sampling_interval * 5
 
     def _wait_ms(self, ms):
         self.reactor.pause(self.reactor.monotonic() + ms / 1000)
 
-    def _read(self, len=1):
+    def _read(self, count=1):
         chunk_size = SGP40_WORD_LEN + 1
-        reply_len = len * chunk_size  # CRC every word
+        reply_len = count * chunk_size
 
-        data = []
+        retries = 5
+        params = None
+        last_error = None
+        while retries > 0 and params is None:
+            try:
+                params = self.i2c.i2c_read([], reply_len, retry=False)
+            except self.printer.command_error as e:
+                last_error = e
+                self._wait_ms(500)
+                retries -= 1
+        if params is None:
+            raise last_error
 
-        params = self.i2c.i2c_read([], reply_len)
         response = bytearray(params["response"])
-
+        data = []
         for i in range(0, reply_len, chunk_size):
             if not _check_crc8(
                 response[i : i + SGP40_WORD_LEN], response[i + SGP40_WORD_LEN]
             ):
                 self._log(WARNING, "Checksum error on read!")
             data.append(unpack_from(">H", response[i : i + SGP40_WORD_LEN])[0])
-
         return data
 
     def _log(self, level, msg):


### PR DESCRIPTION
## Summary

- Intercepts `invoke_shutdown()` calls from Klipper's `bus.py:i2c_transfer()` by replacing `i2c_transfer_cmd` with a wrapper that raises `command_error` instead on non-SUCCESS I2C status
- Patches the SGP40's own I2C object and any I2C-based ref sensors (e.g. BME280)
- Wraps only the I2C operations in `_handle_step` in a try/except; on failure, logs the error and backs off for 5× the sampling interval rather than crashing the printer

## Requirements

MCU firmware must be compiled and flashed from Klipper v0.13.0-159 or newer. A stale MCU firmware build may not support the `i2c_transfer` command that this patch relies on, and the NACK interception will not take effect.

## Test plan

- [x] Verify normal operation: VOC readings update as expected with no errors
- [x] Simulate transient NACK (e.g. briefly disconnect sensor during operation): Klipper should log the error and resume readings after backoff, not shut down
- [ ] Verify startup failure still crashes Klipper (sensor absent/unresponsive at boot should be a hard failure)
- [x] Verify ref sensor (BME280) NACK during operation is also handled gracefully
- [x] Confirm no regression when `ref_temp_sensor` and `ref_humidity_sensor` point to the same sensor (double-patch guard)