### PR TITLE
Add cross-sensor variance floor synchronization via sync_with

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ sensor_type: SGP40
 #heater_temp: 75.0
 #   A temperature (in Celsius) that the heater must rise above before
 #   calibration is disabled. The default is 75 Celsius.
+#sync_with:
+#   The name of another SGP40 sensor to synchronize with. When two sensors
+#   are paired (e.g. intake and exhaust), this keeps their VOC index readings
+#   on a comparable scale. Set to the other sensor's name on both sensors.
 ```
 
 ### Example
@@ -112,6 +116,7 @@ i2c_mcu: nevermore
 i2c_bus: i2c1_PB8_PB9
 ref_temp_sensor: bme280 BME_OUT
 ref_humidity_sensor: bme280 BME_OUT
+sync_with: SGP_IN
 
 [temperature_sensor SGP_IN]
 sensor_type: SGP40
@@ -119,6 +124,7 @@ i2c_mcu: nevermore
 i2c_bus: i2c2_PB10_PB11
 ref_temp_sensor: bme280 BME_IN
 ref_humidity_sensor: bme280 BME_IN
+sync_with: SGP_OUT
 ```
 
 ## Calibration

--- a/src/klipper_sgp40/__init__.py
+++ b/src/klipper_sgp40/__init__.py
@@ -94,6 +94,9 @@ class SGP40:
         if mean is not None and stddev is not None:
             self._gia.set_states(mean, stddev)
 
+        self._sync_peer_name = config.get("sync_with", None)
+        self._sync_peer = None
+
         self.printer.add_object("sgp40 " + self.name, self)
         if self.printer.get_start_args().get("debugoutput") is not None:
             return
@@ -175,6 +178,11 @@ class SGP40:
             raise self.printer.config_error("'%s' does not report %s." % (name, value))
 
     def _handle_connect(self):
+        if self._sync_peer_name:
+            self._sync_peer = self.printer.lookup_object(
+                "sgp40 " + self._sync_peer_name
+            )
+
         if self.temp_sensor:
             self._check_ref_sensor(self.temp_sensor, "temperature")
         if self.humidity_sensor:
@@ -228,6 +236,8 @@ class SGP40:
             # Calculate VOC index
             response = self._read()
             raw = response[0]
+            if self._sync_peer is not None:
+                self._gia.apply_variance_floor(self._sync_peer._gia)
             self.voc = self._gia.process(raw)
             self.raw = self._gia.raw
             # Small delay after read to prevent I2C bus conflicts

--- a/src/klipper_sgp40/gia.py
+++ b/src/klipper_sgp40/gia.py
@@ -126,6 +126,12 @@ class GasIndexAlgorithm:
     def raw(self):
         return self._sraw
 
+    def apply_variance_floor(self, other):
+        """Raise this instance's variance std to at least the other's value."""
+        if other._mve_std > self._mve_std:
+            self._mve_std = other._mve_std
+            self._mox_set_parameters(self._mve_std, self._mve_offset_mean)
+
     def process(self, sraw):
         """Calculate the gas index value from the raw sensor value.
 


### PR DESCRIPTION
## Summary

- Adds a `sync_with` config option to pair two SGP40 sensors (e.g. intake and exhaust)
- Each sensor raises its GIA variance std to at least the paired sensor's value before processing each reading, keeping VOC index scales comparable
- Adds `apply_variance_floor` method to `GasIndexAlgorithm`

## Details

The VOC index linear component is `(raw - mean) / variance`, so two sensors with different variance estimates map the same raw signal change to different index scales. A sensor in a baffled airflow environment may converge to a tighter variance — not because the air is less volatile, but because signal fluctuations are dampened. The shared floor prevents that sensor from becoming artificially sensitive relative to its partner.

Inspired by the same technique in [nevermore-controller](https://github.com/SanaaHamel/nevermore-controller) firmware (`src/sensors/gas_index.hpp`).

## Test plan

- [x] Configure two SGP40s with `sync_with` pointing at each other and verify both report
- [x] Verify a single SGP40 without `sync_with` is unaffected
- [x] Verify `QUERY_SGP40` still reports correctly on both sensors